### PR TITLE
Remove FQDN for hostnames in userdata bash for all hosts

### DIFF
--- a/manager/main.tf
+++ b/manager/main.tf
@@ -9,15 +9,6 @@ resource "openstack_compute_instance_v2" "docker-manager" {
   network {
     name = var.internal_network_name
   }
-  user_data = <<EOF
-#!/bin/bash
-# Use full qualified private DNS name for the host name.  Kube wants it this way.
-HOSTNAME=$(curl http://169.254.169.254/latest/meta-data/hostname)
-echo $HOSTNAME > /etc/hostname
-sed -i "s|\(127\.0\..\.. *\)localhost|\1$HOSTNAME localhost|" /etc/hosts
-hostname $HOSTNAME
-EOF
-
 }
 
 resource "openstack_networking_floatingip_v2" "docker-manager" {

--- a/msr/main.tf
+++ b/msr/main.tf
@@ -11,13 +11,6 @@ resource "openstack_compute_instance_v2" "docker-msr" {
   }
 
   user_data = <<EOF
-#!/bin/bash
-# Use full qualified private DNS name for the host name.  Kube wants it this way.
-HOSTNAME=$(curl http://169.254.169.254/latest/meta-data/hostname)
-echo $HOSTNAME > /etc/hostname
-sed -i "s|\(127\.0\..\.. *\)localhost|\1$HOSTNAME localhost|" /etc/hosts
-hostname $HOSTNAME
-
 yum install -y nfs-utils || apt install -y nfs-common || zypper -n in nfs-client -y
 EOF
 

--- a/worker/main.tf
+++ b/worker/main.tf
@@ -9,16 +9,6 @@ resource "openstack_compute_instance_v2" "docker-worker" {
   network {
     name = var.internal_network_name
   }
-
-  user_data = <<EOF
-#!/bin/bash
-# Use full qualified private DNS name for the host name.  Kube wants it this way.
-HOSTNAME=$(curl http://169.254.169.254/latest/meta-data/hostname)
-echo $HOSTNAME > /etc/hostname
-sed -i "s|\(127\.0\..\.. *\)localhost|\1$HOSTNAME localhost|" /etc/hosts
-hostname $HOSTNAME
-EOF
-
 }
 
 resource "openstack_networking_floatingip_v2" "docker-worker" {


### PR DESCRIPTION
Openstack CCM is trying to find nodes in Openstack Nova using their hostnames. So for example, when you're setting hostname to FQDN, the hostname of the node will be something like this: `worker-0.novalocal`, but the node name in Nova of this machine will be `worker-0`. Because of this misconfiguration, Openstack CCM is not able to find and register nodes.